### PR TITLE
Update PaytrHelper.php

### DIFF
--- a/libraries/PaytrHelper.php
+++ b/libraries/PaytrHelper.php
@@ -59,17 +59,19 @@ class PaytrHelper
     /**
      * @return mixed
      */
-    public function getUserIp()
-    {
-        if( isset( $_SERVER["HTTP_CLIENT_IP"] ) ) {
-            $ip = $_SERVER["HTTP_CLIENT_IP"];
-        } elseif( isset( $_SERVER["HTTP_X_FORWARDED_FOR"] ) ) {
+    public function getUserIp() {
+        if (isset($_SERVER["HTTP_CF_CONNECTING_IP"])) {
+            $ip = $_SERVER["HTTP_CF_CONNECTING_IP"];
+        } elseif (isset($_SERVER["HTTP_X_FORWARDED_FOR"])) {
             $ip = $_SERVER["HTTP_X_FORWARDED_FOR"];
+        } elseif (isset($_SERVER["HTTP_CLIENT_IP"])) {
+            $ip = $_SERVER["HTTP_CLIENT_IP"];
         } else {
             $ip = $_SERVER["REMOTE_ADDR"];
         }
         return $ip;
     }
+
 
     /**
      * @param $value


### PR DESCRIPTION
I modified the code to prioritize retrieving the visitor's IP address from the HTTP_CF_CONNECTING_IP header, which is specific to Cloudflare. If this header exists and contains a value, the function uses this IP address. If the HTTP_CF_CONNECTING_IP header isn't present, the function then checks other common headers (HTTP_X_FORWARDED_FOR, HTTP_CLIENT_IP, and defaults to REMOTE_ADDR) to retrieve the IP address. This adjustment enables the function to effectively capture the real IP addresses of visitors coming through Cloudflare.